### PR TITLE
Fix for daily interval trigger serialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ obj/
 [Rr]elease*/
 _ReSharper*/
 [Tt]est[Rr]esult*
+src/packages

--- a/src/Quartz.Impl.MongoDB.Tests/App.config
+++ b/src/Quartz.Impl.MongoDB.Tests/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <connectionStrings>
+    <add name="quartznet-mongodb" connectionString="server=localhost;database=quartznet_tests"/>
+  </connectionStrings>
+</configuration>

--- a/src/Quartz.Impl.MongoDB.Tests/Properties/AssemblyInfo.cs
+++ b/src/Quartz.Impl.MongoDB.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Quartz.Impl.MongoDB.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Microsoft")]
+[assembly: AssemblyProduct("Quartz.Impl.MongoDB.Tests")]
+[assembly: AssemblyCopyright("Copyright © Microsoft 2012")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("53a44f9d-6275-4377-b804-940ce08bcfb9")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Quartz.Impl.MongoDB.Tests/Quartz.Impl.MongoDB.Tests.csproj
+++ b/src/Quartz.Impl.MongoDB.Tests/Quartz.Impl.MongoDB.Tests.csproj
@@ -1,19 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>8.0.30703</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{41AFEE84-1EE9-4457-917A-52632B55A1BA}</ProjectGuid>
+    <ProjectGuid>{9E7E992E-48B2-4736-88A3-D65E736AD753}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Quartz.Impl.MongoDB</RootNamespace>
-    <AssemblyName>Quartz.Impl.MongoDB</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <RootNamespace>Quartz.Impl.MongoDB.Tests</RootNamespace>
+    <AssemblyName>Quartz.Impl.MongoDB.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile />
-    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\src\</SolutionDir>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -42,40 +40,37 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Common.Logging.2.0.0\lib\2.0\Common.Logging.dll</HintPath>
     </Reference>
-    <Reference Include="MongoDB.Bson, Version=1.7.0.4714, Culture=neutral, PublicKeyToken=f686731cfb9cc103, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\mongocsharpdriver.1.7\lib\net35\MongoDB.Bson.dll</HintPath>
+    <Reference Include="Machine.Specifications">
+      <HintPath>..\packages\Machine.Specifications.0.5.10\lib\net40\Machine.Specifications.dll</HintPath>
     </Reference>
-    <Reference Include="MongoDB.Driver, Version=1.7.0.4714, Culture=neutral, PublicKeyToken=f686731cfb9cc103, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\mongocsharpdriver.1.7\lib\net35\MongoDB.Driver.dll</HintPath>
+    <Reference Include="Machine.Specifications.Clr4">
+      <HintPath>..\packages\Machine.Specifications.0.5.10\lib\net40\Machine.Specifications.Clr4.dll</HintPath>
     </Reference>
     <Reference Include="Quartz, Version=2.0.1.100, Culture=neutral, PublicKeyToken=f6b8c98a402cc8a4, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Quartz.2.0.1\lib\net40\Quartz.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="CalendarWrapper.cs" />
-    <Compile Include="DateTimeOffsetSerializer.cs" />
-    <Compile Include="JobKeySerializer.cs" />
-    <Compile Include="JobDataMapSerializer.cs" />
-    <Compile Include="JobDetailImplSerializer.cs" />
-    <Compile Include="JobStore.cs" />
-    <Compile Include="IdOrKeyConvention.cs" />
+    <Compile Include="TriggerSpecs.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="SetSerializer.cs" />
-    <Compile Include="TriggerKeySerializer.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="App.config" />
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Quartz.Impl.MongoDB\Quartz.Impl.MongoDB.csproj">
+      <Project>{41afee84-1ee9-4457-917a-52632b55a1ba}</Project>
+      <Name>Quartz.Impl.MongoDB</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />

--- a/src/Quartz.Impl.MongoDB.Tests/TriggerSpecs.cs
+++ b/src/Quartz.Impl.MongoDB.Tests/TriggerSpecs.cs
@@ -1,0 +1,52 @@
+﻿using Machine.Specifications;
+namespace Quartz.Impl.MongoDB.Tests
+{
+    using System;
+    using System.Collections.Specialized;
+    using System.Diagnostics;
+    using System.Linq;
+    using System.Threading;
+
+    using Common.Logging.Simple;
+
+    using Quartz.Spi;
+
+    public class TriggerSpecs
+    {
+        public class When_a_daily_interval_trigger_has_been_stored_in_the_mongo_db
+        {
+            private Establish context = () =>
+                {
+                    jobStore = new JobStore();
+                    jobStore.ClearAllSchedulingData();
+                    trigger = TriggerBuilder.Create()
+                        .ForJob(new JobKey("test"))
+                        .WithDailyTimeIntervalSchedule(x => x.OnEveryDay().StartingDailyAt(new TimeOfDay(10, 10)))
+                        .Build();
+                    jobDetail = JobBuilder.Create<TestJob>().WithIdentity("test").Build();
+                };
+
+            private Because of = () => jobStore.StoreJobAndTrigger(jobDetail, (IOperableTrigger)trigger);
+
+            private It should_be_able_to_get_the_trigger_back_from_the_db = () =>
+                {
+                    var triggersForJob = jobStore.GetTriggersForJob(new JobKey("test")).ToList();
+                    triggersForJob.Count.ShouldEqual(1);
+                };
+
+            private static JobStore jobStore;
+
+            private static ITrigger trigger;
+
+            private static IJobDetail jobDetail;
+        }
+    }
+
+    public class TestJob: IJob
+    {
+        public void Execute(IJobExecutionContext context)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Quartz.Impl.MongoDB.Tests/packages.config
+++ b/src/Quartz.Impl.MongoDB.Tests/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Common.Logging" version="2.0.0" targetFramework="net45" />
+  <package id="Machine.Specifications" version="0.5.10" targetFramework="net45" />
+  <package id="Quartz" version="2.0.1" targetFramework="net45" />
+</packages>

--- a/src/Quartz.Impl.MongoDB/JobStore.cs
+++ b/src/Quartz.Impl.MongoDB/JobStore.cs
@@ -143,6 +143,8 @@ namespace Quartz.Impl.MongoDB
                 new DateTimeOffsetSerializer()
             );
 
+            BsonSerializer.RegisterGenericSerializerDefinition(typeof(Collection.ISet<>), typeof(SetSerializer<>));
+
             BsonClassMap.RegisterClassMap<AbstractTrigger>(cm =>
             {
                 cm.AutoMap();

--- a/src/Quartz.Impl.MongoDB/SetSerializer.cs
+++ b/src/Quartz.Impl.MongoDB/SetSerializer.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+
+using MongoDB.Bson.IO;
+using MongoDB.Bson.Serialization;
+
+namespace Quartz.Impl.MongoDB
+{
+    public class SetSerializer<T> : IBsonSerializer
+    {
+        private IBsonSerializer enumerableSerializer;
+
+        public SetSerializer()
+        {
+            enumerableSerializer = BsonSerializer.LookupSerializer(typeof(IEnumerable<T>));
+        }
+
+        public object Deserialize(BsonReader bsonReader, Type nominalType, IBsonSerializationOptions options)
+        {
+            return Deserialize(bsonReader, options);
+        }
+
+        public object Deserialize(BsonReader bsonReader, Type nominalType, Type actualType, IBsonSerializationOptions options)
+        {
+            return Deserialize(bsonReader, options);
+        }
+
+        private object Deserialize(BsonReader bsonReader, IBsonSerializationOptions options)
+        {
+            var enumerable = (IEnumerable<T>)enumerableSerializer.Deserialize(bsonReader, typeof(ISet<T>), typeof(HashSet<T>), options);
+            return new Quartz.Collection.HashSet<T>(enumerable);
+        }
+
+        public IBsonSerializationOptions GetDefaultSerializationOptions()
+        {
+            return enumerableSerializer.GetDefaultSerializationOptions();
+        }
+
+        public void Serialize(BsonWriter bsonWriter, Type nominalType, object value, IBsonSerializationOptions options)
+        {
+            var hashSet = (Collection.HashSet<T>)value;
+            enumerableSerializer.Serialize(bsonWriter, typeof(ISet<T>), new HashSet<T>(hashSet), options);
+        }
+    }
+}

--- a/src/Quartz.Impl.MongoDB/packages.config
+++ b/src/Quartz.Impl.MongoDB/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Common.Logging" version="2.1.1" targetFramework="net40" />
-  <package id="mongocsharpdriver" version="1.5" targetFramework="net40" />
+  <package id="Common.Logging" version="2.0.0" targetFramework="net40" />
+  <package id="mongocsharpdriver" version="1.7" targetFramework="net40" />
   <package id="Quartz" version="2.0.1" targetFramework="net40" />
 </packages>

--- a/src/QuartzNET-MongoDB.sln
+++ b/src/QuartzNET-MongoDB.sln
@@ -1,6 +1,6 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2010
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Quartz.Impl.MongoDB", "Quartz.Impl.MongoDB\Quartz.Impl.MongoDB.csproj", "{41AFEE84-1EE9-4457-917A-52632B55A1BA}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "package", "package", "{8341DC55-5656-478A-B15F-CD3CC0C087C0}"
@@ -15,6 +15,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{F970C7
 		.nuget\NuGet.exe = .nuget\NuGet.exe
 		.nuget\NuGet.targets = .nuget\NuGet.targets
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Quartz.Impl.MongoDB.Tests", "Quartz.Impl.MongoDB.Tests\Quartz.Impl.MongoDB.Tests.csproj", "{9E7E992E-48B2-4736-88A3-D65E736AD753}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -36,6 +38,16 @@ Global
 		{41AFEE84-1EE9-4457-917A-52632B55A1BA}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{41AFEE84-1EE9-4457-917A-52632B55A1BA}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{41AFEE84-1EE9-4457-917A-52632B55A1BA}.Release|x86.ActiveCfg = Release|Any CPU
+		{9E7E992E-48B2-4736-88A3-D65E736AD753}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9E7E992E-48B2-4736-88A3-D65E736AD753}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9E7E992E-48B2-4736-88A3-D65E736AD753}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{9E7E992E-48B2-4736-88A3-D65E736AD753}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{9E7E992E-48B2-4736-88A3-D65E736AD753}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9E7E992E-48B2-4736-88A3-D65E736AD753}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9E7E992E-48B2-4736-88A3-D65E736AD753}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9E7E992E-48B2-4736-88A3-D65E736AD753}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{9E7E992E-48B2-4736-88A3-D65E736AD753}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{9E7E992E-48B2-4736-88A3-D65E736AD753}.Release|x86.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
The DailyTimeIntervalTriggerImpl cannot be serialized without defining a serializer for the custom quartz ISet interface. I wrote a test that tests this issue (check the app.config in test project for the connection string if you want to run this test).

Additionally I've updated the mongo driver to the newest version (there is still a warning because of an obsolete api usage). I hope I will find some time to fix that.
