### PR TITLE
Upgrading to Quartz 2.1.1

### DIFF
--- a/src/Quartz.Impl.MongoDB.Tests/Quartz.Impl.MongoDB.Tests.csproj
+++ b/src/Quartz.Impl.MongoDB.Tests/Quartz.Impl.MongoDB.Tests.csproj
@@ -32,13 +32,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="C5, Version=1.1.0.0, Culture=neutral, PublicKeyToken=06a1b38866503b69, processorArchitecture=MSIL">
+    <Reference Include="Common.Logging, Version=2.1.2.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Quartz.2.0.1\lib\net40\C5.dll</HintPath>
-    </Reference>
-    <Reference Include="Common.Logging, Version=2.0.0.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Common.Logging.2.0.0\lib\2.0\Common.Logging.dll</HintPath>
+      <HintPath>..\packages\Common.Logging.2.1.2\lib\net40\Common.Logging.dll</HintPath>
     </Reference>
     <Reference Include="Machine.Specifications">
       <HintPath>..\packages\Machine.Specifications.0.5.10\lib\net40\Machine.Specifications.dll</HintPath>
@@ -46,9 +42,9 @@
     <Reference Include="Machine.Specifications.Clr4">
       <HintPath>..\packages\Machine.Specifications.0.5.10\lib\net40\Machine.Specifications.Clr4.dll</HintPath>
     </Reference>
-    <Reference Include="Quartz, Version=2.0.1.100, Culture=neutral, PublicKeyToken=f6b8c98a402cc8a4, processorArchitecture=MSIL">
+    <Reference Include="Quartz, Version=2.1.1.400, Culture=neutral, PublicKeyToken=f6b8c98a402cc8a4, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Quartz.2.0.1\lib\net40\Quartz.dll</HintPath>
+      <HintPath>..\packages\Quartz.2.1.1\lib\net40\Quartz.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/Quartz.Impl.MongoDB.Tests/packages.config
+++ b/src/Quartz.Impl.MongoDB.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Common.Logging" version="2.0.0" targetFramework="net45" />
+  <package id="Common.Logging" version="2.1.2" targetFramework="net45" />
   <package id="Machine.Specifications" version="0.5.10" targetFramework="net45" />
-  <package id="Quartz" version="2.0.1" targetFramework="net45" />
+  <package id="Quartz" version="2.1.1" targetFramework="net45" />
 </packages>

--- a/src/Quartz.Impl.MongoDB/JobStore.cs
+++ b/src/Quartz.Impl.MongoDB/JobStore.cs
@@ -384,6 +384,19 @@ namespace Quartz.Impl.MongoDB
             }
         }
 
+        public void StoreJobsAndTriggers(IDictionary<IJobDetail, Collection.ISet<ITrigger>> triggersAndJobs, bool replace)
+        {
+            var dictionary = new Dictionary<IJobDetail, IList<ITrigger>>();
+
+            foreach (var triggersAndJob in triggersAndJobs)
+            {
+                dictionary.Add(triggersAndJob.Key, triggersAndJob.Value.ToList());
+            }
+
+            StoreJobsAndTriggers(new Dictionary<IJobDetail, IList<ITrigger>>(dictionary), replace);
+
+        }
+
         /// <summary>
         /// Remove (delete) the <see cref="IJob" /> with the given
         /// name, and any <see cref="ITrigger" /> s that reference
@@ -1419,7 +1432,8 @@ namespace Quartz.Impl.MongoDB
                     // put it back into the timeTriggers set and continue to search for next trigger.
                     JobKey jobKey = trigger.JobKey;
                     IJobDetail job = this.Jobs.FindOneByIdAs<IJobDetail>(jobKey.ToBsonDocument());
-                    if (job.ConcurrentExectionDisallowed)
+                    
+                    if (job.ConcurrentExecutionDisallowed)
                     {
                         if (acquiredJobKeysForNoConcurrentExec.Contains(jobKey))
                         {
@@ -1530,7 +1544,7 @@ namespace Quartz.Impl.MongoDB
 
                     IJobDetail job = bndle.JobDetail;
 
-                    if (job.ConcurrentExectionDisallowed)
+                    if (job.ConcurrentExecutionDisallowed)
                     {
                         var jobTriggers = this.GetTriggersForJob(job.Key);
                         IEnumerable<BsonDocument> triggerKeys = jobTriggers
@@ -1586,7 +1600,7 @@ namespace Quartz.Impl.MongoDB
                         Update.Set("JobDataMap", jobDetail.JobDataMap.ToBsonDocument()));
                 }
 
-                if (jobDetail.ConcurrentExectionDisallowed)
+                if (jobDetail.ConcurrentExecutionDisallowed)
                 {
                     IList<Spi.IOperableTrigger> jobTriggers = this.GetTriggersForJob(jobDetail.Key);
                     IEnumerable<BsonDocument> triggerKeys = jobTriggers.Select(t => t.Key.ToBsonDocument());

--- a/src/Quartz.Impl.MongoDB/Quartz.Impl.MongoDB.csproj
+++ b/src/Quartz.Impl.MongoDB/Quartz.Impl.MongoDB.csproj
@@ -34,13 +34,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="C5, Version=1.1.0.0, Culture=neutral, PublicKeyToken=06a1b38866503b69, processorArchitecture=MSIL">
+    <Reference Include="Common.Logging, Version=2.1.2.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Quartz.2.0.1\lib\net40\C5.dll</HintPath>
-    </Reference>
-    <Reference Include="Common.Logging, Version=2.0.0.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Common.Logging.2.0.0\lib\2.0\Common.Logging.dll</HintPath>
+      <HintPath>..\packages\Common.Logging.2.1.2\lib\net40\Common.Logging.dll</HintPath>
     </Reference>
     <Reference Include="MongoDB.Bson, Version=1.7.0.4714, Culture=neutral, PublicKeyToken=f686731cfb9cc103, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -50,9 +46,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\mongocsharpdriver.1.7\lib\net35\MongoDB.Driver.dll</HintPath>
     </Reference>
-    <Reference Include="Quartz, Version=2.0.1.100, Culture=neutral, PublicKeyToken=f6b8c98a402cc8a4, processorArchitecture=MSIL">
+    <Reference Include="Quartz, Version=2.1.1.400, Culture=neutral, PublicKeyToken=f6b8c98a402cc8a4, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Quartz.2.0.1\lib\net40\Quartz.dll</HintPath>
+      <HintPath>..\packages\Quartz.2.1.1\lib\net40\Quartz.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.configuration" />

--- a/src/Quartz.Impl.MongoDB/packages.config
+++ b/src/Quartz.Impl.MongoDB/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Common.Logging" version="2.0.0" targetFramework="net40" />
+  <package id="Common.Logging" version="2.1.2" targetFramework="net40" />
   <package id="mongocsharpdriver" version="1.7" targetFramework="net40" />
-  <package id="Quartz" version="2.0.1" targetFramework="net40" />
+  <package id="Quartz" version="2.1.1" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
The latest Quartz 2.1.1 introduced an additional method on the IJobStore interface - 

```
void StoreJobsAndTriggers(IDictionary<IJobDetail, Collection.ISet<ITrigger>> triggersAndJobs, bool replace)
```

I have simply reused the original StoreJobsAndTriggers method by mapping the set of triggers to a list of triggers. Feel free to change otherwise.

Thanks

Hope it helps.
