### PR TITLE
Remove requirement for connection string in web or app config file

### DIFF
--- a/src/Quartz.Impl.MongoDB/JobStore.cs
+++ b/src/Quartz.Impl.MongoDB/JobStore.cs
@@ -70,6 +70,8 @@ namespace Quartz.Impl.MongoDB
         private MongoCollection BlockedJobs { get { return this.database.GetCollection(instanceName + ".BlockedJobs"); } }
         private MongoCollection Schedulers { get { return this.database.GetCollection(instanceName + ".Schedulers"); } }
 
+        public static string DefaultConnectionString { get; set; }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="JobStore"/> class.
         /// </summary>
@@ -77,14 +79,19 @@ namespace Quartz.Impl.MongoDB
         {
             log = LogManager.GetLogger(GetType());
 
-            string connectionString = ConfigurationManager.ConnectionStrings["quartznet-mongodb"].ConnectionString;
+            string connectionString;
+
+            if( ConfigurationManager.ConnectionStrings["quartznet-mongodb"] != null )
+                connectionString = ConfigurationManager.ConnectionStrings["quartznet-mongodb"].ConnectionString;
+            else
+                connectionString = DefaultConnectionString;
 
             //
             // If there is no connection string to use then throw an 
             // exception to abort construction.
             //
 
-            if (connectionString.Length == 0)
+            if (string.IsNullOrWhiteSpace(connectionString))
                 throw new ApplicationException("Connection string is missing for the MongoDB job store.");
 
             lock (lockObject)


### PR DESCRIPTION
Remove the requirement for connection string in web or app config file to make clustered deploys easier. I.e. allow a fully in-code configuration.

I've simply added a static property for setting the default value. Using DI would probably have been a better design but that would entail taking a dependency on a DI container. This method is cheap but it works well enough IMO
