### PR TITLE
conversions are applied for Quartz.* namespace only

### DIFF
--- a/src/Quartz.Impl.MongoDB/JobStore.cs
+++ b/src/Quartz.Impl.MongoDB/JobStore.cs
@@ -109,7 +109,7 @@ namespace Quartz.Impl.MongoDB
             myConventions.SetIdMemberConvention(new IdOrKeyConvention());
             BsonClassMap.RegisterConventions(
                 myConventions,
-                t => true
+                t => t.FullName.StartsWith("Quartz.")
             );
 
             BsonSerializer.RegisterSerializer(


### PR DESCRIPTION
Conversions are used in the library interfere with client code so I've decided to add that limitation.
